### PR TITLE
並列処理を追加しました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
+# fork of [mozcdict-ext](https://github.com/reasonset/mozcdict-ext)
+# 目的
+mozcのパッケージ作成において、システム辞書として、有志が公開してくださっている辞書を含めることが目的です。  
+
+下記サイトに、まとめてくださっています。感謝です。  
+- [Merge UT Dictionaries merges multiple Mozc UT dictionaries into one and modify the costs.](https://github.com/utuhiro78/merge-ut-dictionaries)  
+このレポジトリにおいては、上記で公開されているUT辞書と、 
+- [sudachidict](https://github.com/WorksApplications/SudachiDict)  
+- [NAIST Japanese Dictionary](https://osdn.net/projects/naist-jdic/)  
+を、mozcdict-extのスクリプトをベースに、それぞれをmozc用の辞書に変換するスクリプトを公開しているリポジトリです。 
+mozcdict-extをベースにしているので、私が書いたスクリプト自体はGPLライセンスになるかと思います。  
+このスクリプトによって生成される辞書ファイルについては、GPLライセンスの適用外になります。  
+ですから、それぞれの辞書の元データのライセンスに基づいて、配布は可能になるかと思います。  
+詳細は、元データの配布者のライセンスをご確認くださいませ。
+
+# スクリプトの使い方の例
+```
+ruby mecab-naist-jdic/mecab-naist-jdic.rb -i id.def -f mecab-naist-jdic-0.6.3b-20111013/naist-jdic.csv -e euc-jp
+ruby utdict/utdict.rb -i id.def -f ut-dictionary1 ut-dictionary2 ...
+ruby sudachi/sudachi.rb -i id.def -f sudachi/src/core_lex.csv sudachi/src/notcore_lex.csv 
+```
+-iオプションでmozcのid.defファイルを指定します。  
+-fオプションで辞書ファイルを指定します。  
+naist-jdic.csvがEUC-JPで配布されていましたので、-eオプションもつけました。  
+入出力ともにUTF-8がデフォルトです。
+
+# ArchLinux向け AURパッケージ
+- [fcitx5-mozc-with-jp-dict](https://aur.archlinux.org/packages/fcitx5-mozc-with-jp-dict)  
+- [ibus-mozc-with-jp-dict](https://aur.archlinux.org/packages/ibus-mozc-with-jp-dict)  
+- [emacs-mozc-with-jp-dict](https://aur.archlinux.org/packages/emacs-mozc-with-jp-dict)  
+- [mozc-with-jp-dict-common](https://aur.archlinux.org/packages/mozc-with-jp-dict-common)    
+にて、AURパッケージを公開しました。
+
+---
 # mozcdict-ext
 
 Convert external words into Mozc system dictionary

--- a/neologd/mkdict.zsh
+++ b/neologd/mkdict.zsh
@@ -16,7 +16,7 @@ then
     git pull
   )
 else
-  git clone 'https://github.com/neologd/mecab-ipadic-neologd.git' upstream
+  git clone --depth 1 --no-single-branch 'https://github.com/neologd/mecab-ipadic-neologd.git' upstream
 fi
 ) > /dev/null
 

--- a/neologd/neologd.rb
+++ b/neologd/neologd.rb
@@ -1,100 +1,122 @@
 #! /usr/bin/env ruby
+# coding: UTF-8
 require 'csv'
 require 'nkf'
 require 'optparse'
+require 'parallel'
 
 ID_DEF = {}
 ALREADY = {}
 
+$opts = { threads: 18, slice: 8000,
+          filename: "src/seed/user-dict-seed.csv",
+          idfile: "../../mozc/src/data/dictionary_oss/id.def"
+}
+
+op = OptionParser.new
+op.on("-e", "--english")
+op.on('-tNUM', '--threads=NUM', Integer ) { |v| $opts[:threads] = v }
+op.on('-sNUM', '--slice=NUM', Integer ) { |v| $opts[:slice] = v }
+op.on('-fVAL', '--filename=VAL', String ) { |v| $opts[:filename] = v }
+op.on('-iVAL', '--idfile=VAL', String ){ |v| $opts[:idfile] = v }
+op.parse!(ARGV, into: $opts)
+
 unless ENV["MOZC_ID_FILE"]
-  abort "Mozc ID Definition File is not given."
+  MOZC_ID_FILE=$opts[:idfile]
+else
+  MOZC_ID_FILE=ENV["MOZC_ID_FILE"]
 end
 
 # Load Mozc ID definition.
-File.open(ENV["MOZC_ID_FILE"], "r") do |f|
+File.open(MOZC_ID_FILE, "r") do |f|
   f.each do |line|
     id, expr = line.chomp.split(" ", 2)
     ID_DEF[expr] = id
   end
 end
 
-$opts = {}
-op = OptionParser.new
-op.on("-e", "--english")
-op.parse!(ARGV, into: $opts)
+# parallel
+THREAD_NUM=$opts[:threads]
+SLICE_NUM=$opts[:slice]
 
 # Read CSV each line from file.
-CSV.foreach("src/seed/user-dict-seed.csv") do |row|
+file = CSV.open($opts[:filename], "r:utf-8")
+file.each_slice(SLICE_NUM) do |rows|
   # 表層形,左文脈ID,右文脈ID,コスト,品詞1,品詞2,品詞3,品詞4,品詞5,品詞6,原形,読み,発音
   # #24時間以内に240RT来なければ俺の嫁,1288,1288,3942,名詞,固有名詞,一般,*,*,*,#24時間以内に240RT来なければ俺の嫁,ニジュウヨジカンイナイニニヒャクヨンジュウアールティーコナケレバオレノヨメ,ニジュウヨジカンイナイニニヒャクヨンジュウアールティーコナケレバオレノヨメ
-  surface, lcxid, rcxid, cost, cls1, cls2, cls3, cls4, cls5, cls6, base, kana, pron = *row
+  results = Parallel.map(rows, in_threads: THREAD_NUM) do | row |
+    surface, lcxid, rcxid, cost, cls1, cls2, cls3, cls4, cls5, cls6, base, kana, pron = row
 
-  yomi = NKF.nkf("--hiragana -w -W", kana).tr("ゐゑ", "いえ")
+    yomi = NKF.nkf("--hiragana -w -W", kana).tr("ゐゑ", "いえ")
 
-  # 読みがひらがな以外を含む場合はスキップ => 検証
-  # 名詞以外の場合はスキップ => しない
+    # 読みがひらがな以外を含む場合はスキップ => 検証
+    # 名詞以外の場合はスキップ => しない
 
-  # 「地域」をスキップ。地名は郵便番号ファイルから生成する => 踏襲する
-  next if cls3 == "地域"
+    # 「地域」をスキップ。地名は郵便番号ファイルから生成する => 踏襲する
+    next if cls3 == "地域"
 
-  # 「名」をスキップ => しない
+    # 「名」をスキップ => しない
 
-  clsexpr = [cls1, cls2, cls3, cls4, cls5, cls6].join(",")
-  cost = cost.to_i
+    clsexpr = [cls1, cls2, cls3, cls4, cls5, cls6].join(",").force_encoding('UTF-8')
+    #clsexpr = [cls1, cls2, cls3, cls4, cls5, cls6].join(",")
+    cost = cost.to_i
 
-  ##### List class (develop feature) #####
-  # puts clsexpr
-  # next
+    ##### List class (develop feature) #####
+    # puts clsexpr
+    # next
 
-  # コスト計算の処理はMozc-UTに倣っている
-  mozc_cost = case
-  when cost < 0
-    # コストがマイナスの場合は8000にする
-    8000
-  when cost > 10000
-		# コストが10000を超える場合は10000にする
-    10000
-  else
-		# コストを 6000 < cost < 7000 に調整する
-    6000 + (cost / 10)
+    # コスト計算の処理はMozc-UTに倣っている
+    mozc_cost = case
+                when cost < 0
+                  # コストがマイナスの場合は8000にする
+                  8000
+                when cost > 10000
+                  # コストが10000を超える場合は10000にする
+                  10000
+                else
+                  # コストを 6000 < cost < 7000 に調整する
+                  6000 + (cost / 10)
+                end
+
+    # idは探索を行う。
+    # 既知のNeologdのクラスを変換
+    # 未知のものは無視する
+    id = case clsexpr
+         when "記号,一般,*,*,*,*"
+           ID_DEF["記号,一般,*,*,*,*,*"]
+         when "名詞,固有名詞,人名,一般,*,*"
+           ID_DEF["名詞,固有名詞,人名,一般,*,*,*"]
+         when "名詞,固有名詞,一般,*,*,*", "名詞,固有名詞,一般,*,*,"
+           ID_DEF["名詞,固有名詞,一般,*,*,*,*"]
+         when "名詞,固有名詞,組織,*,*,*"
+           ID_DEF["名詞,固有名詞,組織,*,*,*,*"]
+         when "名詞,一般,*,*,*,*"
+           ID_DEF["名詞,一般,*,*,*,*,*"]
+         when "名詞,サ変接続,*,*,*,*"
+           ID_DEF["名詞,サ変接続,*,*,*,*,*"]
+         when "名詞,固有名詞,人名,名,*,*"
+           ID_DEF["名詞,固有名詞,人名,名,*,*,*"]
+         when "名詞,固有名詞,人名,姓,*,*"
+           ID_DEF["名詞,固有名詞,人名,姓,*,*,*"]
+         end
+
+    #raise unless id      # DEVELOPMENT MODE
+    next unless id
+
+    # 英語への変換はオプションによる (デフォルトスキップ)
+    # 固有名詞は受け入れる
+    next if (!$opts[:english] && base =~ /^[a-zA-Z ]+$/ && !clsexpr.include?("固有名詞") )
+
+    generic_expr = [yomi, id,  base].join(" ")
+    if ALREADY[generic_expr]
+      next
+    else
+      ALREADY[generic_expr] = true
+      line_expr = [yomi, id, id, mozc_cost, base]
+    end
   end
-
-  # idは探索を行う。
-  # 既知のNeologdのクラスを変換
-  # 未知のものは無視する
-  id = case clsexpr
-  when "記号,一般,*,*,*,*"
-    ID_DEF["記号,一般,*,*,*,*,*"]
-  when "名詞,固有名詞,人名,一般,*,*"
-    ID_DEF["名詞,固有名詞,人名,一般,*,*,*"]
-  when "名詞,固有名詞,一般,*,*,*", "名詞,固有名詞,一般,*,*,"
-    ID_DEF["名詞,固有名詞,一般,*,*,*,*"]
-  when "名詞,固有名詞,組織,*,*,*"
-    ID_DEF["名詞,固有名詞,組織,*,*,*,*"]
-  when "名詞,一般,*,*,*,*"
-    ID_DEF["名詞,一般,*,*,*,*,*"]
-  when "名詞,サ変接続,*,*,*,*"
-    ID_DEF["名詞,サ変接続,*,*,*,*,*"]
-  when "名詞,固有名詞,人名,名,*,*"
-    ID_DEF["名詞,固有名詞,人名,名,*,*,*"]
-  when "名詞,固有名詞,人名,姓,*,*"
-    ID_DEF["名詞,固有名詞,人名,姓,*,*,*"]
-  end
-
-  #raise unless id      # DEVELOPMENT MODE
-  next unless id
-
-  # 英語への変換はオプションによる (デフォルトスキップ)
-  # 固有名詞は受け入れる
-  next if (!$opts[:english] && base =~ /^[a-zA-Z ]+$/ && !clsexpr.include?("固有名詞") )
-  
-  line_expr = [yomi, id, id, mozc_cost, base].join("\t")
-  generic_expr = [yomi, id,  base].join(" ")
-  if ALREADY[generic_expr]
-    next
-  else
-    ALREADY[generic_expr] = true
-  end
-
-  puts line_expr
+  results.map{ |x|
+    next if x.nil?
+    puts x.join("\t")
+  }
 end

--- a/sudachi/sudachi.rb
+++ b/sudachi/sudachi.rb
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
+# coding: UTF-8
 require 'csv'
 require 'nkf'
 require 'yaml'
 require 'optparse'
+require 'parallel'
 
 ##### CONSTANTS #####
 ROUND = !(ENV["WORDCLASS_ROUND"]&.downcase == "no")
@@ -14,92 +16,112 @@ CLASS_MAP = YAML.load(File.read("clsmap.yaml"))
 ID_DEF = {}
 ALREADY = {}
 
+$opts = { threads: 18, slice: 8000,
+          filename: [ "src/core_lex.csv", "src/notcore_lex.csv" ],
+          idfile: "../../mozc/src/data/dictionary_oss/id.def"
+}
+op = OptionParser.new
+op.on("-e", "--english")
+op.on("-s", "--symbol")
+op.on('-tNUM', '--threads=NUM', Integer ) { |v| $opts[:threads] = v }
+op.on('-sNUM', '--slice=NUM', Integer ) { |v| $opts[:slice] = v }
+op.on('-fVAL', '--filename=VAL', String ) { |v| $opts[:filename] = v }
+op.on('-iVAL', '--idfile=VAL', String ){ |v| $opts[:idfile] = v }
+op.parse!(ARGV, into: $opts)
+
 unless ENV["MOZC_ID_FILE"]
-  abort "Mozc ID Definition File is not given."
+  MOZC_ID_FILE=$opts[:idfile]
+else
+  MOZC_ID_FILE=ENV["MOZC_ID_FILE"]
 end
 
 # Load Mozc ID definition.
-File.open(ENV["MOZC_ID_FILE"], "r") do |f|
+File.open(MOZC_ID_FILE, "r") do |f|
   f.each do |line|
     id, expr = line.chomp.split(" ", 2)
     ID_DEF[expr] = id
   end
 end
 
-$opts = {}
-op = OptionParser.new
-op.on("-e", "--english")
-op.on("-s", "--symbol")
-op.parse!(ARGV, into: $opts)
+# parallel
+THREAD_NUM=$opts[:threads]
+SLICE_NUM=$opts[:slice]
 
 # baseball heroes,4785,4785,5000,BASEBALL HEROES,名詞,固有名詞,一般,*,*,*,ベースボールヒーローズ,BASEBALL HEROES,*,A,*,*,*,*
 # 見出し (TRIE 用),左連接ID,右連接ID,コスト,見出し (解析結果表示用), 品詞1,品詞2,品詞3,品詞4,品詞 (活用型),品詞 (活用形), 読み,正規化表記,辞書形ID,分割タイプ,A単位分割情報,B単位分割情報,※未使用
 
-["src/core_lex.csv", "src/notcore_lex.csv"].each do |source_file|
-  CSV.foreach(source_file) do |row|
-    head_trie, lid, rid, cost, head_anal, cls1, cls2, cls3, cls4, cls5, cls6, kana, normal, did, dtype, adiv, bdiv = *row
+#["src/core_lex.csv", "src/notcore_lex.csv"].each do |source_file|
+$opts[:filename].each do |source_file|
+  file = CSV.open(source_file, "r:utf-8")
+  file.each_slice(SLICE_NUM) do |rows|
+    results = Parallel.map(rows, in_threads: THREAD_NUM) do | row |
+      head_trie, lid, rid, cost, head_anal, cls1, cls2, cls3, cls4, cls5, cls6, kana, normal, did, dtype, adiv, bdiv = *row
 
-    # 読みがかなで構成されていないものを除外する
-    next if kana =~ /[^\p{hiragana}\p{katakana}ー]/
+      # 読みがかなで構成されていないものを除外する
+      next if kana =~ /[^\p{hiragana}\p{katakana}ー]/
 
-    yomi = NKF.nkf("--hiragana -w -W", kana).tr("ゐゑ", "いえ")
+      yomi = NKF.nkf("--hiragana -w -W", kana).tr("ゐゑ", "いえ")
 
-    # 見出し (解析結果表示用)を表記とみなす
-    base = head_anal
-    
-    # head_trie と conv_to が casecmp false な例:
-    # ["co・cp共済", "4785", "4785", "15000", "CO･CP共済", "名詞", "固有名詞", "一般", "*", "*", "*", "コープキョウサイ", "コープ共済", "*", "A", "*", "*", "*", "021722"]
-    # Mozcdic-UTではスキップされていたが、こちらは単純に解析結果表示用を採用することとする
-    # next unless head_trie.casecmp(conv_to).zero?
+      # 見出し (解析結果表示用)を表記とみなす
+      base = head_anal
 
-    # 名詞以外の場合はスキップ => しない
-    # 「地名」をスキップ。地名は郵便番号ファイルから生成する => 踏襲
-    next if cls3 == "地名"
-		# 「名」をスキップ => しない
+      # head_trie と conv_to が casecmp false な例:
+      # ["co・cp共済", "4785", "4785", "15000", "CO･CP共済", "名詞", "固有名詞", "一般", "*", "*", "*", "コープキョウサイ", "コープ共済", "*", "A", "*", "*", "*", "021722"]
+      # Mozcdic-UTではスキップされていたが、こちらは単純に解析結果表示用を採用することとする
+      # next unless head_trie.casecmp(conv_to).zero?
 
-    clsexpr = [cls1, cls2, cls3, cls4, cls5, cls6].join(",")
-    cost = cost.to_i
+      # 名詞以外の場合はスキップ => しない
+      # 「地名」をスキップ。地名は郵便番号ファイルから生成する => 踏襲
+      next if cls3 == "地名"
+      # 「名」をスキップ => しない
 
-    # コスト計算の処理はMozc-UTに倣っている
-    mozc_cost = case
-    when cost < 0
-      # コストがマイナスの場合は8000にする
-      8000
-    when cost > 10000
-      # コストが10000を超える場合は10000にする
-      10000
-    else
-      # コストを 6000 < cost < 7000 に調整する
-      6000 + (cost / 10)
+      clsexpr = [cls1, cls2, cls3, cls4, cls5, cls6].join(",")
+      cost = cost.to_i
+
+      # コスト計算の処理はMozc-UTに倣っている
+      mozc_cost = case
+                  when cost < 0
+                    # コストがマイナスの場合は8000にする
+                    8000
+                  when cost > 10000
+                    # コストが10000を超える場合は10000にする
+                    10000
+                  else
+                    # コストを 6000 < cost < 7000 に調整する
+                    6000 + (cost / 10)
+                  end
+
+      ##### List class (develop feature) #####
+      # puts clsexpr
+      # next
+
+      # 既知のクラスの変換
+      id = ID_DEF[CLASS_MAP[clsexpr]]
+
+      # 品詞が特定できないケース
+      if !id
+        ERROR_UNEXPECTED_CLS ? abort("Unexpected Word Class #{clsexpr}") : next
+      end
+
+      # 英語への変換はオプションによる (デフォルトスキップ)
+      # 固有名詞は受け入れる
+      next if (!$opts[:english] && base =~ /^[a-zA-Z ]+$/ && !clsexpr.include?("固有名詞") )
+
+      # 「きごう」で変換される記号は多すぎて支障をきたすため、除外する
+      next if (!$opts[:symbol] && yomi == "きごう" && clsexpr.include?("記号"))
+
+      generic_expr = [yomi, id, base].join(" ")
+      if ALREADY[generic_expr]
+        next
+      else
+        ALREADY[generic_expr] = true
+        line_expr = [yomi, id, id, mozc_cost, base]
+      end
     end
 
-    ##### List class (develop feature) #####
-    # puts clsexpr
-    # next
-
-    # 既知のクラスの変換
-    id = ID_DEF[CLASS_MAP[clsexpr]]
-
-    # 品詞が特定できないケース
-    if !id
-      ERROR_UNEXPECTED_CLS ? abort("Unexpected Word Class #{clsexpr}") : next
-    end
-
-    # 英語への変換はオプションによる (デフォルトスキップ)
-    # 固有名詞は受け入れる
-    next if (!$opts[:english] && base =~ /^[a-zA-Z ]+$/ && !clsexpr.include?("固有名詞") )
-
-    # 「きごう」で変換される記号は多すぎて支障をきたすため、除外する
-    next if (!$opts[:symbol] && yomi == "きごう" && clsexpr.include?("記号"))
-
-    line_expr = [yomi, id, id, mozc_cost, base].join("\t")
-    generic_expr = [yomi, id, base].join(" ")
-    if ALREADY[generic_expr]
-      next
-    else
-      ALREADY[generic_expr] = true
-    end
-  
-    puts line_expr
+    results.map{ |x|
+      next if x.nil?
+      puts x.join("\t")
+    }
   end
 end

--- a/utdict/utdict.rb
+++ b/utdict/utdict.rb
@@ -38,41 +38,8 @@ File.open(MOZC_ID_FILE, "r") do |f|
   f.each do |line|
     id, expr = line.chomp.split(" ", 2)
     #id.defの品詞の末尾要素を取り除く
-    expr = expr.split(",")
-    expr.pop
-    expr = expr.join(",")
     ID_DEF[expr] = id
   end
-end
-
-# 一番近いだろう品詞を求める。
-# 単純な判定なので、誤る場合もあります。
-def id_expr(clsexpr)
-  expr=clsexpr.split(",")
-  r=nil
-  q=0
-  ID_DEF.keys.each do |h|
-    p=0
-    expr.each do |x|
-      next if x == "*"
-      i = h.split(",")
-      i.each do |y|
-        case y
-        when "*","自立","非自立"
-          next
-        end
-        if x == y
-          p = p + 1
-        end
-      end
-    end
-    if q < p
-      q = p
-      r = ID_DEF[h]
-    end
-  end
-  ID_DEF[clsexpr] = r if not ID_DEF.include?(clsexpr)
-  return r
 end
 
 # parallel
@@ -80,10 +47,9 @@ THREAD_NUM=$opts[:threads]
 SLICE_NUM=$opts[:slice]
 
 # Read CSV each line from file.
-file = CSV.open($opts[:filename], "r", encoding: $opts[:fileencoding], liberal_parsing: false)
+file = CSV.open($opts[:filename], "r", col_sep: "\t", encoding: $opts[:fileencoding], liberal_parsing: true)
 file.each_slice(SLICE_NUM) do |rows|
-  # 表層形,左文脈ID,右文脈ID,コスト,品詞1,品詞2,品詞3,品詞4,品詞5,品詞6,原形,読み,発音
-  # #24時間以内に240RT来なければ俺の嫁,1288,1288,3942,名詞,固有名詞,一般,*,*,*,#24時間以内に240RT来なければ俺の嫁,ニジュウヨジカンイナイニニヒャクヨンジュウアールティーコナケレバオレノヨメ,ニジュウヨジカンイナイニニヒャクヨンジュウアールティーコナケレバオレノヨメ
+  # 読み,左文脈ID,右文脈ID,コスト,原形
   results = Parallel.map(rows, in_threads: THREAD_NUM) do | row |
     if $opts[:need_convert]
       row.each do |x|
@@ -91,21 +57,13 @@ file.each_slice(SLICE_NUM) do |rows|
         x.replace(NKF.nkf('-w', x))
       end
     end
-    surface, lcxid, rcxid, cost, cls1, cls2, cls3, cls4, cls5, cls6, base, kana, pron = row
-    yomi = NKF.nkf("--hiragana -w -W", kana).tr("ゐゑ", "いえ")
+    yomi, lcxid, rcxid, cost, base = row
+    yomi = NKF.nkf("--hiragana -w -W", yomi).tr("ゐゑ", "いえ")
 
     # 読みがひらがな以外を含む場合はスキップ => 検証
-    #if /[^\u3040-\u309F]/ !~ yomi
-    next if /[\p{hiragana}\p{katakana}]/ !~ kana
+    next if /[\p{hiragana}\p{katakana}]/ !~ yomi
     # 名詞以外の場合はスキップ => しない
 
-    # 「地域」をスキップ。地名は郵便番号ファイルから生成する => 踏襲する
-    next if cls3 == "地域"
-
-    # 「名」をスキップ => しない
-
-    clsexpr = [cls1, cls2, cls3, cls4, cls5, cls6].join(",").force_encoding('UTF-8')
-    #clsexpr = [cls1, cls2, cls3, cls4, cls5, cls6].join(",")
     cost = cost.to_i
 
     ##### List class (develop feature) #####
@@ -126,27 +84,20 @@ file.each_slice(SLICE_NUM) do |rows|
                 end
 
     # idは探索を行う。
-    # 既知のNeologdのクラスを変換
     # 未知のものは無視する
-    #next if not ID_DEF.has_key?(clsexpr)
-    id = ID_DEF[clsexpr]
-    if id.nil?
-      id = id_expr(clsexpr)
-      STDERR.puts row if id.nil?
-    end
-    #raise unless id      # DEVELOPMENT MODE
+    id = lcxid
     next unless id
 
     # 英語への変換はオプションによる (デフォルトスキップ)
     # 固有名詞は受け入れる
-    next if (!$opts[:english] && base =~ /^[a-zA-Z ]+$/ && !clsexpr.include?("固有名詞") )
+    next if (!$opts[:english] && base =~ /^[a-zA-Z ]+$/ && !id.include?("固有名詞") )
 
     generic_expr = [yomi, id,  base].join(" ")
     if ALREADY[generic_expr]
       next
     else
       ALREADY[generic_expr] = true
-      line_expr = [yomi, id, id, mozc_cost, base]
+      line_expr = [yomi, lcxid, rcxid , mozc_cost, base]
     end
   end
   results.map{ |x|
@@ -154,4 +105,3 @@ file.each_slice(SLICE_NUM) do |rows|
     puts x.join("\t")
   }
 end
-


### PR DESCRIPTION
Aimed at saving time, parallel processing was added using the parallel library. Added option to specify paths to external files such as id.def.

並列処理を追加しました。
時間短縮を狙い、parallelライブラリを用いて並列処理を追加しました。
id.defなど外部ファイルのパスを指定するオプションを追加しました。